### PR TITLE
Check if $GLOBALS['TSFE'] is initialized

### DIFF
--- a/Classes/Hooks/FormElementCaptchaHook.php
+++ b/Classes/Hooks/FormElementCaptchaHook.php
@@ -59,11 +59,14 @@ class FormElementCaptchaHook
             $renderable->setProperty('fluidAdditionalAttributes', $properties['fluidAdditionalAttributes']);
 
             // Add cache identifier to captchaIds array + write it to cookie
-            $captchaIds = $GLOBALS['TSFE']->fe_user->getKey('ses', 'captchaIds') ?? [];
-            if (!in_array($cacheIdentifier, $captchaIds)) {
-                $captchaIds[] = $cacheIdentifier;
-                $GLOBALS['TSFE']->fe_user->setKey('ses', 'captchaIds', $captchaIds);
-                $GLOBALS['TSFE']->fe_user->storeSessionData();
+            $tsfe = $GLOBALS['TSFE'] ?? null;
+            if ($tsfe) {
+                $captchaIds = $GLOBALS['TSFE']->fe_user->getKey('ses', 'captchaIds') ?? [];
+                if (!in_array($cacheIdentifier, $captchaIds)) {
+                    $captchaIds[] = $cacheIdentifier;
+                    $tsfe->fe_user->setKey('ses', 'captchaIds', $captchaIds);
+                    $tsfe->fe_user->storeSessionData();
+                }
             }
 
             // add controller name to element


### PR DESCRIPTION
If the hook FormElementCaptchaHook is executed in the backend in preview mode, $GLOBALS['TSFE'] may not be initialized.

Also, it is no longer considered good practice to access $GLOBALS['TSFE'] directly, but an alternative is missing in this case.

Resolves: #25