### PR TITLE
Fix: Add cache headers + cHash exclude parameter

### DIFF
--- a/Classes/Middleware/Captcha.php
+++ b/Classes/Middleware/Captcha.php
@@ -60,10 +60,10 @@ class Captcha implements MiddlewareInterface
             ->withHeader('Pragma-Directive', 'no-cache')
             ->withHeader('Expires', '0');
 
-        // add Content-Length header in case of onload request (no reload)
+        // add Content-Length header in case of onload request (no reload) or logged in backend user
         $binaryImage = $builder->get();
         $params = $request->getQueryParams();
-        if (!isset($params['now'])) {
+        if (!isset($params['now']) || isset($GLOBALS['BE_USER'])) {
             $contentLength = floor((strlen($binaryImage) + 2) / 3) * 4;
             $response = $response->withHeader('Content-Length', (string)$contentLength);
         }

--- a/Classes/Middleware/Captcha.php
+++ b/Classes/Middleware/Captcha.php
@@ -52,14 +52,19 @@ class Captcha implements MiddlewareInterface
         $newPhrase = $builder->getPhrase() ?? '';
         $this->storePhraseToSession($newPhrase, $request, $lifetime);
 
+        // calculate content length
+        $binaryImage = $builder->get();
+        $contentLength = floor((strlen($binaryImage) + 2) / 3) * 4;
+
         // render captcha image
         $response = $this->responseFactory->createResponse()
             ->withHeader('Content-Type', 'image/jpeg')
             ->withHeader('Cache-Control', 'no-cache')
             ->withHeader('Cache-Directive', 'no-cache')
             ->withHeader('Pragma-Directive', 'no-cache')
-            ->withHeader('Expires', '0');
-        $response->getBody()->write($builder->get());
+            ->withHeader('Expires', '0')
+            ->withHeader('Content-Length', (string)$contentLength);
+        $response->getBody()->write($binaryImage);
         return $response;
     }
 

--- a/Classes/Middleware/Captcha.php
+++ b/Classes/Middleware/Captcha.php
@@ -60,10 +60,10 @@ class Captcha implements MiddlewareInterface
             ->withHeader('Pragma-Directive', 'no-cache')
             ->withHeader('Expires', '0');
 
-        // add Content-Length header in case of onload request (no reload) or logged in backend user
+        // add Content-Length header in case of onload request (no reload)
         $binaryImage = $builder->get();
         $params = $request->getQueryParams();
-        if (!isset($params['now']) && !isset($GLOBALS['BE_USER'])) {
+        if (!isset($params['now'])) {
             $contentLength = floor((strlen($binaryImage) + 2) / 3) * 4;
             $response = $response->withHeader('Content-Length', (string)$contentLength);
         }

--- a/Classes/Middleware/Captcha.php
+++ b/Classes/Middleware/Captcha.php
@@ -52,10 +52,19 @@ class Captcha implements MiddlewareInterface
         $newPhrase = $builder->getPhrase() ?? '';
         $this->storePhraseToSession($newPhrase, $request, $lifetime);
 
+        // calculate content length
+        $binaryImage = $builder->get();
+        $contentLength = floor((strlen($binaryImage) + 2) / 3) * 4;
+
         // render captcha image
         $response = $this->responseFactory->createResponse()
-            ->withHeader('Content-Type', 'image/jpeg');
-        $response->getBody()->write($builder->get());
+            ->withHeader('Content-Type', 'image/jpeg')
+            ->withHeader('Cache-Control', 'no-cache')
+            ->withHeader('Cache-Directive', 'no-cache')
+            ->withHeader('Pragma-Directive', 'no-cache')
+            ->withHeader('Expires', '0')
+            ->withHeader('Content-Length', (string)$contentLength);
+        $response->getBody()->write($binaryImage);
         return $response;
     }
 

--- a/Classes/Middleware/Captcha.php
+++ b/Classes/Middleware/Captcha.php
@@ -52,19 +52,14 @@ class Captcha implements MiddlewareInterface
         $newPhrase = $builder->getPhrase() ?? '';
         $this->storePhraseToSession($newPhrase, $request, $lifetime);
 
-        // calculate content length
-        $binaryImage = $builder->get();
-        $contentLength = floor((strlen($binaryImage) + 2) / 3) * 4;
-
         // render captcha image
         $response = $this->responseFactory->createResponse()
             ->withHeader('Content-Type', 'image/jpeg')
             ->withHeader('Cache-Control', 'no-cache')
             ->withHeader('Cache-Directive', 'no-cache')
             ->withHeader('Pragma-Directive', 'no-cache')
-            ->withHeader('Expires', '0')
-            ->withHeader('Content-Length', (string)$contentLength);
-        $response->getBody()->write($binaryImage);
+            ->withHeader('Expires', '0');
+        $response->getBody()->write($builder->get());
         return $response;
     }
 

--- a/Classes/Middleware/Captcha.php
+++ b/Classes/Middleware/Captcha.php
@@ -63,7 +63,7 @@ class Captcha implements MiddlewareInterface
         // add Content-Length header in case of onload request (no reload) or logged in backend user
         $binaryImage = $builder->get();
         $params = $request->getQueryParams();
-        if (!isset($params['now']) || isset($GLOBALS['BE_USER'])) {
+        if (!isset($params['now']) && !isset($GLOBALS['BE_USER'])) {
             $contentLength = floor((strlen($binaryImage) + 2) / 3) * 4;
             $response = $response->withHeader('Content-Length', (string)$contentLength);
         }

--- a/Resources/Private/Frontend/Partials/Captcha.html
+++ b/Resources/Private/Frontend/Partials/Captcha.html
@@ -6,7 +6,7 @@
 		<div class="captcha">
 			<img src="{f:uri.page(pageType:3413)}" alt="Captcha image" loading="lazy" onload="this.parentElement.classList.remove('captcha--reloading'); return false;"/>
 			<f:if condition="{element.properties.showRefresh}">
-				<a class="captcha__reload" href="#" data-url="{f:uri.page(pageType:3413)}" onclick="const div = this.parentElement; div.classList.add('captcha--reloading', 'captcha--spin'); let captchaUrl = this.dataset.url; this.previousElementSibling.setAttribute('src', captchaUrl + (/\?/.test(captchaUrl) ? '&' : '?') + Date.now()); setTimeout(function(){div.classList.remove('captcha--spin')},400); return false;">
+				<a class="captcha__reload" href="#" data-url="{f:uri.page(pageType:3413)}" onclick="const div = this.parentElement; div.classList.add('captcha--reloading', 'captcha--spin'); let captchaUrl = this.dataset.url; this.previousElementSibling.setAttribute('src', captchaUrl + (/\?/.test(captchaUrl) ? '&' : '?') + 'now=' + Date.now()); setTimeout(function(){div.classList.remove('captcha--spin')},400); return false;">
 					<svg width="31" height="28" xmlns="http://www.w3.org/2000/svg">
 						<g fill="#000" fill-rule="evenodd">
 							<path d="M10 10.7 6.3 8.5a11 11 0 0 1 20 3l2.5-.8h.4v-.3A14 14 0 0 0 3.6 7L.3 5l1.8 8.3 8-2.6ZM31 23l-1.7-8-8 2.5 3.7 2.1a10.9 10.9 0 0 1-19.8-2.3l-2 .6-1 .3a13.9 13.9 0 0 0 17 9.3 14 14 0 0 0 8.4-6.4l3.4 2Z"/>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -19,4 +19,10 @@ call_user_func(function () {
         \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
         ['source' => 'EXT:bw_captcha/Resources/Public/Images/form-captcha-icon.svg']
     );
+
+    $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'] ??= [];
+    \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule(
+        $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'],
+        ['now']
+    );
 });


### PR DESCRIPTION
This PR solves problems regarding caching issues:

* Add `Content-Length` and multiple `Cache-Control` headers in order to prevent browser from caching captcha image on reload.
* Add named URL parameter `now` to image src when reloading via JavaScript

resolves #38 