### PR TITLE
fix: remove Content-Length header

### DIFF
--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -4,14 +4,20 @@ return [
     'frontend' => [
         'bw-captcha/captcha' => [
             'target' => Blueways\BwCaptcha\Middleware\Captcha::class,
-            'after'  => [
-                'typo3-cms/frontend/tsfe',
+            'after' => [
+                'typo3/cms-frontend/prepare-tsfe-rendering',
+            ],
+            'before' => [
+                'typo3/cms-frontend/output-compression',
             ],
         ],
         'bw-captcha/audio' => [
             'target' => Blueways\BwCaptcha\Middleware\Audio::class,
-            'after'  => [
-                'typo3-cms/frontend/tsfe',
+            'after' => [
+                'typo3/cms-frontend/prepare-tsfe-rendering',
+            ],
+            'before' => [
+                'typo3/cms-frontend/output-compression',
             ],
         ],
     ],


### PR DESCRIPTION
Remove the `Content-Length` header that was set to prevent image caching when logged into the TYPO3 backend (cache headers become overriden). To avoid the cache header override, the backend authentication is unset in the middleware.

The middleware order has been adjusted as well.