### PR TITLE
fix: abort audio middleware for non post requests

### DIFF
--- a/Classes/Middleware/Audio.php
+++ b/Classes/Middleware/Audio.php
@@ -39,7 +39,7 @@ class Audio implements MiddlewareInterface
     ): ResponseInterface {
         /** @var PageArguments $pageArguments */
         $pageArguments = $request->getAttribute('routing', null);
-        if ($pageArguments->getPageType() !== '3414') {
+        if ($pageArguments->getPageType() !== '3414' || $request->getMethod() !== 'POST') {
             // pipe request to other middleware handlers
             return $handler->handle($request);
         }


### PR DESCRIPTION
Calling `?type=3414` via GET requests causes an undefined array key error in the middleware. This is due to the fact that the TypoScript is not fully loaded at this point, see [Documentation](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/RequestLifeCycle/Middlewares.html#using-extbase). Thanks @tgaertner

It should be evaluated if captcha settings should be migrated from TypoScript to extension settings. 