### PR TITLE
fix: language code retrieval

### DIFF
--- a/Classes/Middleware/Audio.php
+++ b/Classes/Middleware/Audio.php
@@ -39,14 +39,14 @@ class Audio implements MiddlewareInterface
     ): ResponseInterface {
         /** @var PageArguments $pageArguments */
         $pageArguments = $request->getAttribute('routing', null);
-        if ($pageArguments->getPageType() !== '3414' || $request->getMethod() !== 'POST') {
+        if ($pageArguments->getPageType() !== '3414' || $request->getMethod() !== 'POST' || $request->getAttribute('frontend.user') === null) {
             // pipe request to other middleware handlers
             return $handler->handle($request);
         }
 
         $locale = $request->getAttribute('language')?->getLocale();
         if ($locale instanceof \TYPO3\CMS\Core\Localization\Locale) {
-            $languageCode = $locale->getCountryCode();
+            $languageCode = $locale->getCountryCode() ?? '';
         } else {
             $languageCode = $request->getAttribute('language')?->getTwoLetterIsoCode() ?? '';
         }
@@ -67,7 +67,7 @@ class Audio implements MiddlewareInterface
             return $handler->handle($request);
         }
 
-        if ((int)$settings['audioButton'] && isset($body['captchaDataUrl'])) {
+        if ((int)$settings['audioButton'] && is_array($body)  && isset($body['captchaDataUrl'])) {
             // get image data from post request
             $dataUrl = $body['captchaDataUrl'];
             [, $dataUrl] = explode(';', $dataUrl);

--- a/Classes/Middleware/Audio.php
+++ b/Classes/Middleware/Audio.php
@@ -44,7 +44,13 @@ class Audio implements MiddlewareInterface
             return $handler->handle($request);
         }
 
-        $languageCode = $request->getAttribute('language')?->getTwoLetterIsoCode() ?? '';
+        $locale = $request->getAttribute('language')?->getLocale();
+        if ($locale instanceof \TYPO3\CMS\Core\Localization\Locale) {
+            $languageCode = $locale->getCountryCode();
+        } else {
+            $languageCode = $request->getAttribute('language')?->getTwoLetterIsoCode() ?? '';
+        }
+
         $body = $request->getParsedBody();
 
         $ts = $this->configurationManager->getConfiguration(

--- a/Classes/Middleware/Captcha.php
+++ b/Classes/Middleware/Captcha.php
@@ -94,6 +94,10 @@ class Captcha implements MiddlewareInterface
         ServerRequestInterface $request,
         int $lifetime = 3600
     ): void {
+        if ($request->getAttribute('frontend.user') === null) {
+            return;
+        }
+
         // write data to session
         $feUser = $request->getAttribute('frontend.user');
         $captchaPhrases = $feUser->getKey('ses', 'captchaPhrases');

--- a/Classes/Utility/AudioBuilderUtility.php
+++ b/Classes/Utility/AudioBuilderUtility.php
@@ -50,7 +50,7 @@ class AudioBuilderUtility
             $info = unpack($fields, $header);
             // read optional extra stuff
             if (isset($info['Subchunk1Size']) && $info['Subchunk1Size'] > 16) {
-                $header .= fread($fp, max(0, (int)$info['Subchunk1Size'] - 16));
+                $header .= fread($fp, max(1, (int)$info['Subchunk1Size'] - 16));
             }
             // read SubChunk2ID
             $header .= fread($fp, 4);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,2 @@
 parameters:
-	ignoreErrors:
-		-
-			message: "#^Cannot access offset 'captchaDataUrl' on array\\|object\\.$#"
-			count: 1
-			path: Classes/Middleware/Audio.php
-
-		-
-			message: "#^Parameter \\#2 \\$length of function fread expects int\\<1, max\\>, int\\<0, max\\> given\\.$#"
-			count: 1
-			path: Classes/Utility/AudioBuilderUtility.php
+	ignoreErrors: []


### PR DESCRIPTION
Migrate from `siteLanguage:twoLetterIsoCode` to `siteLanguage:locale:languageCode`. Keep v11 fallback. See TYPO3 [changelog](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.3/Deprecation-99905-SiteLanguageIso-639-1Setting.html)