### PR TITLE
feat: add required attribute

### DIFF
--- a/Configuration/Yaml/FormConfiguration.yaml
+++ b/Configuration/Yaml/FormConfiguration.yaml
@@ -68,6 +68,7 @@ TYPO3:
               properties:
                 fluidAdditionalAttributes:
                   autocomplete: 'off'
+                  required: 'required'
               variants:
                 - identifier: template-variant
                   condition: 'getRootFormProperty("renderingOptions.templateVariant") == "version2"'

--- a/Resources/Private/SfEventMgt/Registration/Captcha/BwCaptcha.html
+++ b/Resources/Private/SfEventMgt/Registration/Captcha/BwCaptcha.html
@@ -53,7 +53,7 @@
             </a>
         </f:if>
     </div>
-    <f:form.textfield id="captcha" property="captcha" /><br>
+    <f:form.textfield id="captcha" property="captcha" required="required" /><br>
     <f:render partial="FormErrors" arguments="{field: 'registration.captcha'}"/>
 </div>
 


### PR DESCRIPTION
This PR adds the attribute `required="required"` to the default captcha form element via `fluidAdditionalAttributes`.  Added to the `sf_event_mgt` partial as well.

Resolves #78 