### PR TITLE
fix: use array append for cacheHash excludedParameters

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,6 +1,5 @@
 <?php
 
-use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 defined('TYPO3') or die();

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -17,8 +17,7 @@ call_user_func(static function () {
         '));
 
     $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'] ??= [];
-    ArrayUtility::mergeRecursiveWithOverrule(
-        $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'],
-        ['now']
-    );
+    if (!in_array('now', $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'], true)) {
+        $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'][] = 'now';
+    }
 });


### PR DESCRIPTION
Replace mergeRecursiveWithOverrule with in_array check and direct array append to prevent key conflicts.

closes #118 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of cache-hash parameter exclusion: the system now appends the "now" parameter only when absent, preventing duplicates and eliminating prior side effects from merge operations. This ensures consistent preservation of existing excluded parameters without altering their order or causing unintended changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->