### PR TITLE
Resolve PHP 8.4 deprecation notice

### DIFF
--- a/Libraries/Captcha/src/Gregwar/Captcha/CaptchaBuilder.php
+++ b/Libraries/Captcha/src/Gregwar/Captcha/CaptchaBuilder.php
@@ -133,7 +133,7 @@ class CaptchaBuilder implements CaptchaBuilderInterface
      */
     public $tempDir = 'temp/';
 
-    public function __construct($phrase = null, PhraseBuilderInterface $builder = null)
+    public function __construct($phrase = null, ?PhraseBuilderInterface $builder = null)
     {
         if ($builder === null) {
             $this->builder = new PhraseBuilder;


### PR DESCRIPTION
This fix adds the nullable type hint for PhraseBuilderInterface param. Done directly in a legacy upstream dependancy. Will be replaced with an updated fork version.

closes #121 