### PR TITLE
[BUGFIX] TS settings may be empty

### DIFF
--- a/Classes/Domain/Model/FormElements/CaptchaElement.php
+++ b/Classes/Domain/Model/FormElements/CaptchaElement.php
@@ -30,7 +30,10 @@ class CaptchaElement extends AbstractFormElement
         $ts = $configurationManager->getConfiguration(
             ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT
         );
-        $settings = $ts['plugin.']['tx_bwcaptcha.']['settings.'];
+        $settings = $ts['plugin.']['tx_bwcaptcha.']['settings.'] ?? null;
+        if ($settings === null) {
+            return;
+        }
         $this->setProperty('showRefresh', (bool)$settings['refreshButton']);
         $this->setProperty('showAudio', (bool)$settings['audioButton']);
     }


### PR DESCRIPTION
e.g. when class is called in BE-Context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CAPTCHA form element to robustly handle missing configuration settings, preventing potential errors and improving overall system reliability during form initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->