### PR TITLE
fix: adjust moved font file paths

### DIFF
--- a/Configuration/Sets/BwCaptcha/settings.definitions.yaml
+++ b/Configuration/Sets/BwCaptcha/settings.definitions.yaml
@@ -29,7 +29,7 @@ settings:
     type: int
     category: bw_captcha.settings
   plugin.tx_bwcaptcha.settings.fontFiles:
-    default: 'EXT:bw_captcha/Libraries/Captcha/src/Gregwar/Captcha/Font/captcha0.ttf,EXT:bw_captcha/Libraries/Captcha/src/Gregwar/Captcha/Font/captcha1.ttf,EXT:bw_captcha/Libraries/Captcha/src/Gregwar/Captcha/Font/captcha3.ttf,EXT:bw_captcha/Libraries/Captcha/src/Gregwar/Captcha/Font/captcha4.ttf,EXT:bw_captcha/Libraries/Captcha/src/Gregwar/Captcha/Font/captcha5.ttf'
+    default: 'EXT:bw_captcha/Resources/Private/Libs/vendor/gregwar/captcha/src/Gregwar/Captcha/Font/captcha0.ttf,EXT:bw_captcha/Resources/Private/Libs/vendor/gregwar/captcha/src/Gregwar/Captcha/Font/captcha1.ttf,EXT:bw_captcha/Resources/Private/Libs/vendor/gregwar/captcha/src/Gregwar/Captcha/Font/captcha3.ttf,EXT:bw_captcha/Resources/Private/Libs/vendor/gregwar/captcha/src/Gregwar/Captcha/Font/captcha4.ttf,EXT:bw_captcha/Resources/Private/Libs/vendor/gregwar/captcha/src/Gregwar/Captcha/Font/captcha5.ttf'
     type: string
     category: bw_captcha.settings
   plugin.tx_bwcaptcha.settings.textColor:

--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -13,7 +13,7 @@ plugin.tx_bwcaptcha {
     # cat=bw_captcha; type=int; label=The height of the image
     height = 40
     # cat=bw_captcha; type=string; label=Custom font file(s) to use (comma-separated): Could be: "EXT:my_site/Resources/Public/Fonts/myFont.ttf" (extension path), "1:myfolder/myFont.ttf" (combined identifier), "23" (file UID), "file:23"
-    fontFiles = EXT:bw_captcha/Libraries/Captcha/src/Gregwar/Captcha/Font/captcha0.ttf,EXT:bw_captcha/Libraries/Captcha/src/Gregwar/Captcha/Font/captcha1.ttf,EXT:bw_captcha/Libraries/Captcha/src/Gregwar/Captcha/Font/captcha3.ttf,EXT:bw_captcha/Libraries/Captcha/src/Gregwar/Captcha/Font/captcha4.ttf,EXT:bw_captcha/Libraries/Captcha/src/Gregwar/Captcha/Font/captcha5.ttf
+    fontFiles = EXT:bw_captcha/Resources/Private/Libs/vendor/gregwar/captcha/src/Gregwar/Captcha/Font/captcha0.ttf,EXT:bw_captcha/Resources/Private/Libs/vendor/gregwar/captcha/src/Gregwar/Captcha/Font/captcha1.ttf,EXT:bw_captcha/Resources/Private/Libs/vendor/gregwar/captcha/src/Gregwar/Captcha/Font/captcha3.ttf,EXT:bw_captcha/Resources/Private/Libs/vendor/gregwar/captcha/src/Gregwar/Captcha/Font/captcha4.ttf,EXT:bw_captcha/Resources/Private/Libs/vendor/gregwar/captcha/src/Gregwar/Captcha/Font/captcha5.ttf
     # cat=bw_captcha; type=string; label=Text color (e.g. 255,0,0)
     textColor =
     # cat=bw_captcha; type=string; label=Line color (e.g. 0,0,0)


### PR DESCRIPTION
In #129 the bundled libraries have been moved to `Resources/Private/Libs` - the font file paths of the default config need to be adjusted accordingly.