### PR TITLE
fix: ambiguous class resolution warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,10 @@
 			"MaikSchneider\\Steganography\\": [
 				"Resources/Private/Libs/vendor/maikschneider/steganography/src"
 			]
-		}
+		},
+		"exclude-from-classmap": [
+			"Resources/Private/Libs/vendor/"
+		]
 	},
 	"config": {
 		"allow-plugins": {


### PR DESCRIPTION
Since v5.4.0, `composer install`/`update` emits "Ambiguous class resolution" warnings for every `gregwar/captcha` and `maikschneider/steganography` class, because each library ships both as a Composer `require` dependency (in `vendor/`) and as a bundled PSR‑4 copy under `Resources/Private/Libs/vendor/` (needed for TER/non‑Composer installs). Composer's classmap generator sees both copies and flags the duplicates.

Add `autoload.exclude-from-classmap` for `Resources/Private/Libs/vendor/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package loading rules to exclude bundled vendor libraries from the generated classmap.
  * Kept existing autoload behavior unchanged for the rest of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->